### PR TITLE
Implements `duck emit` to serialize Asts to a file

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ colored = "2"
 heck = "0.4"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+serde_yaml = "0.8"
 toml = "0.5"
 pretty_assertions = "1.1"
 unicode-segmentation = "1.9"

--- a/cli/input.rs
+++ b/cli/input.rs
@@ -14,9 +14,8 @@ pub struct Cli {
 pub enum Commands {
     /// Runs the primary linting process.
     Run {
-        /// The path to the project directory to lint. Uses the current
-        /// directory if not provided.
-        #[clap(long, parse(from_os_str))]
+        /// The path to the project directory to run on. Uses the current directory if not provided.
+        #[clap(long, short, parse(from_os_str))]
         path: Option<PathBuf>,
 
         /// Prevents duck from returning a non-zero status due to lint warnings.
@@ -44,6 +43,23 @@ pub enum Commands {
     },
     /// Prints the provided lint's explanation for what it does and why it may be useful.
     Explain { lint_name: String },
+    /// Serializes Asts into a file.
+    ///
+    /// Files that contain errors will not be included in the output.
+    Emit {
+        /// The name of the file to output to.
+        #[clap(parse(from_os_str))]
+        output_path: PathBuf,
+
+        /// The path to the project directory to serialize. Uses the current directory if not
+        /// provided. Can alternatively pass the path to a singular gml file.
+        #[clap(long, short, parse(from_os_str))]
+        path: Option<PathBuf>,
+
+        /// The format to serialize the Asts as. Defaults to JSON
+        #[clap(short, long, arg_enum)]
+        format: Option<EmitFormat>,
+    },
 }
 
 #[derive(Parser, Debug, Copy, Clone, ArgEnum)]
@@ -60,4 +76,10 @@ impl From<ConfigTemplate> for Config {
             ConfigTemplate::Full => Config::full(),
         }
     }
+}
+
+#[derive(Parser, Debug, Copy, Clone, ArgEnum)]
+pub enum EmitFormat {
+    Json,
+    Yaml,
 }

--- a/cli/main.rs
+++ b/cli/main.rs
@@ -272,6 +272,10 @@ async fn emit(path: Option<PathBuf>, output_path: PathBuf, format: Option<EmitFo
         EmitFormat::Yaml => serde_yaml::to_string(&emit).unwrap(),
     };
     std::fs::write(output_path, output_data).unwrap();
+    println!(
+        "{}: duck is not yet stabalized, and the format produced by this command may change without announcement. Until things are more settled, you can find an overview written in JSON of the types this command produces here: https://github.com/imlazyeye/duck/pull/1#issuecomment-1126736509",
+        "WARNING".bright_yellow().bold(),
+    );
     Ok(())
 }
 

--- a/src/core/driver.rs
+++ b/src/core/driver.rs
@@ -179,7 +179,7 @@ fn run_late_lint_on_expr<T: Lint + LateExprPass>(expr: &Expr, config: &Config, r
 pub fn start_gml_discovery(directory: &Path) -> (Receiver<PathBuf>, JoinHandle<Vec<std::io::Error>>) {
     /// Filters DirEntry's for gml files.
     async fn filter(entry: DirEntry) -> Filtering {
-        if let Some(true) = entry.path().file_name().map(|f| !f.to_string_lossy().ends_with(".gml")) {
+        if entry.file_name().to_str().map_or(false, |f| !f.contains(".gml")) {
             Filtering::Ignore
         } else {
             Filtering::Continue
@@ -229,7 +229,7 @@ pub fn start_file_load(
                 Ok(gml) => {
                     let gml: &'static str = Box::leak(Box::new(gml));
                     lines += gml.lines().count();
-                    let file_id = files.add(path.to_str().unwrap().to_string(), gml);
+                    let file_id = files.add(path.canonicalize().unwrap().to_str().unwrap().to_string(), gml);
                     file_sender.send((file_id, gml)).await.unwrap();
                 }
                 Err(io_error) => io_errors.push(io_error),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,12 +107,12 @@ pub mod parse {
             pub use with::*;
         }
         mod expr;
-        mod optional_initialization;
+        mod field;
         mod stmt;
         mod token;
         pub use expr::*;
         pub use expressions::*;
-        pub use optional_initialization::*;
+        pub use field::*;
         pub use statements::*;
         pub use stmt::*;
         pub use token::*;

--- a/src/lint/collection/condition_wrapper.rs
+++ b/src/lint/collection/condition_wrapper.rs
@@ -60,7 +60,7 @@ impl EarlyStmtPass for ConditionWrapper {
     fn visit_stmt_early(stmt: &Stmt, config: &Config, reports: &mut Vec<Diagnostic<FileId>>) {
         match stmt.kind() {
             StmtKind::Switch(Switch {
-                matching_value: expr, ..
+                identity: expr, ..
             })
             | StmtKind::If(If { condition: expr, .. })
             | StmtKind::DoUntil(DoUntil { condition: expr, .. })

--- a/src/parse/ast.rs
+++ b/src/parse/ast.rs
@@ -3,7 +3,8 @@ use crate::parse::ParseVisitor;
 use super::{Expr, Stmt};
 
 /// A collection of statements.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Ast {
     stmts: Vec<Stmt>,
 }
@@ -28,36 +29,47 @@ impl Ast {
         &mut self.stmts
     }
 
-    /// Returns all nodes in the ast that match the provided tag.
-    pub fn tagged_nodes(&self, tag: &Tag) -> Vec<Node> {
-        fn visit_expr(expr: &Expr, nodes: &mut Vec<Node>, tag: &Tag) {
-            if expr.tag() == Some(tag) {
+    /// Returns all nodes in the ast that match the provided tag, or have any tag at all if None is
+    /// provided.
+    pub fn tagged_nodes(&self, tag: Option<&Tag>) -> Vec<Node> {
+        fn collect_tagged_exprs(expr: &Expr, nodes: &mut Vec<Node>, tag: Option<&Tag>) {
+            let matches = match (tag, expr.tag()) {
+                (None, Some(_)) => true,
+                (Some(t1), Some(t2)) if t1 == t2 => true,
+                _ => false,
+            };
+            if matches {
                 nodes.push(Node::Expr(expr.clone()));
             }
-            expr.visit_child_stmts(|stmt| visit_stmt(stmt, nodes, tag));
-            expr.visit_child_exprs(|expr| visit_expr(expr, nodes, tag));
+            expr.visit_child_stmts(|stmt| collect_tagged_stmts(stmt, nodes, tag));
+            expr.visit_child_exprs(|expr| collect_tagged_exprs(expr, nodes, tag));
         }
-        fn visit_stmt(stmt: &Stmt, nodes: &mut Vec<Node>, tag: &Tag) {
-            if stmt.tag() == Some(tag) {
+        fn collect_tagged_stmts(stmt: &Stmt, nodes: &mut Vec<Node>, tag: Option<&Tag>) {
+            let matches = match (tag, stmt.tag()) {
+                (None, Some(_)) => true,
+                (Some(t1), Some(t2)) if t1 == t2 => true,
+                _ => false,
+            };
+            if matches {
                 nodes.push(Node::Stmt(stmt.clone()));
             }
-            stmt.visit_child_stmts(|stmt| visit_stmt(stmt, nodes, tag));
-            stmt.visit_child_exprs(|expr| visit_expr(expr, nodes, tag));
+            stmt.visit_child_stmts(|stmt| collect_tagged_stmts(stmt, nodes, tag));
+            stmt.visit_child_exprs(|expr| collect_tagged_exprs(expr, nodes, tag));
         }
         let mut nodes = vec![];
         for stmt in self.stmts() {
-            visit_stmt(stmt, &mut nodes, tag);
+            collect_tagged_stmts(stmt, &mut nodes, tag);
         }
         nodes
     }
 }
 
 /// An identifier for an individual Ast.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default, serde::Serialize)]
 pub struct AstId(u64);
 
 /// The data from a user-written tag (ie: #[allow(draw_text)])
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
 pub struct Tag(pub String, pub Option<String>);
 impl PartialEq<(&str, Option<&str>)> for Tag {
     fn eq(&self, other: &(&str, Option<&str>)) -> bool {
@@ -66,10 +78,20 @@ impl PartialEq<(&str, Option<&str>)> for Tag {
 }
 
 /// A container for both expressions and statements.
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, serde::Serialize)]
+#[serde(rename_all = "snake_case", tag = "node_kind")]
 pub enum Node {
     /// Contains a [Stmt].
     Stmt(Stmt),
     /// Contains an [Expr].
     Expr(Expr),
+}
+impl Node {
+    /// Returns the tag the node contains.
+    pub fn tag(&self) -> Option<&Tag> {
+        match self {
+            Node::Stmt(stmt) => stmt.tag(),
+            Node::Expr(expr) => expr.tag(),
+        }
+    }
 }

--- a/src/parse/gml/expr.rs
+++ b/src/parse/gml/expr.rs
@@ -261,8 +261,10 @@ impl std::fmt::Display for Expr {
                 ..
             }) => {
                 let constructor_str = match constructor {
-                    Some(Constructor::WithInheritance(call)) => format!(": {call} constructor"),
-                    Some(Constructor::WithoutInheritance) => "constructor".into(),
+                    Some(Constructor {
+                        inheritance: Some(expr),
+                    }) => format!(": {expr} constructor"),
+                    Some(_) => "constructor".into(),
                     None => "".into(),
                 };
                 let param_str = parameters.iter().join(", ");

--- a/src/parse/gml/expr.rs
+++ b/src/parse/gml/expr.rs
@@ -3,7 +3,8 @@ use crate::{parse::*, FileId};
 use itertools::Itertools;
 
 /// A singular gml statement.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "expr_kind", rename_all = "snake_case")]
 pub enum ExprKind {
     /// Declaration of a function.
     Function(Function),
@@ -114,11 +115,16 @@ impl ExprKind {
 impl IntoExpr for ExprKind {}
 
 /// A wrapper around an [ExprType], containing additional information discovered while parsing.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Expr {
+    #[serde(flatten)]
     expr_type: Box<ExprKind>,
+    #[serde(skip)]
     id: ExprId,
+    #[serde(skip)]
     location: Location,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tag: Option<Tag>,
 }
 impl Expr {
@@ -364,7 +370,7 @@ pub trait IntoExpr: Sized + Into<ExprKind> {
 }
 
 /// A unique id that each [Expr] has.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default, serde::Serialize)]
 pub struct ExprId(u64);
 impl ExprId {
     /// Creates a new, random ExprId.

--- a/src/parse/gml/expressions/access.rs
+++ b/src/parse/gml/expressions/access.rs
@@ -4,7 +4,7 @@ use super::Identifier;
 
 /// Representation of a access in gml, such as an array lookup, or dot-notation.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-#[serde(rename_all = "snake_case", tag = "type")]
+#[serde(rename_all = "snake_case", tag = "access")]
 pub enum Access {
     /// Accessing the global scope via `global.`.
     Global {

--- a/src/parse/gml/expressions/access.rs
+++ b/src/parse/gml/expressions/access.rs
@@ -3,22 +3,26 @@ use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt};
 use super::Identifier;
 
 /// Representation of a access in gml, such as an array lookup, or dot-notation.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
 pub enum Access {
     /// Accessing the global scope via `global.`.
     Global {
         /// The value being extracted from the global scope.
+        #[serde(flatten)]
         right: Identifier,
     },
     /// Accessing the current scope via `self`. (This would be called `Self`, but its reserved by
     /// rust.)
     Identity {
         /// The value being extracted from the local scope.
+        #[serde(flatten)]
         right: Identifier,
     },
     /// Accessing the scope above the current one via `other`.
     Other {
         /// The value being extracted from the other scope.
+        #[serde(flatten)]
         right: Identifier,
     },
     /// Dot access with any struct or object.
@@ -26,6 +30,7 @@ pub enum Access {
         /// The value being accessed.
         left: Expr,
         /// The value being extracted from the leftside value.
+        #[serde(flatten)]
         right: Identifier,
     },
     /// Array access. The bool at the end represents if the `@` accessor is present, which denotes

--- a/src/parse/gml/expressions/call.rs
+++ b/src/parse/gml/expressions/call.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt};
 
 /// Representation of an assignment expression in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Call {
     /// The leftside of the call (the value being invoked).
     pub left: Expr,

--- a/src/parse/gml/expressions/equality.rs
+++ b/src/parse/gml/expressions/equality.rs
@@ -37,7 +37,7 @@ impl ParseVisitor for Equality {
 
 /// The various equality operations supported in gml.
 #[derive(Debug, PartialEq, Copy, Clone, serde::Serialize)]
-#[serde(tag = "type", content = "token", rename_all = "snake_case")]
+#[serde(tag = "op", content = "token", rename_all = "snake_case")]
 pub enum EqualityOp {
     /// =, ==
     Equal(Token),

--- a/src/parse/gml/expressions/equality.rs
+++ b/src/parse/gml/expressions/equality.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt, Token};
 
 /// Representation of a equality expression in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Equality {
     /// The left hand side of the equality.
     pub left: Expr,
@@ -36,7 +36,8 @@ impl ParseVisitor for Equality {
 }
 
 /// The various equality operations supported in gml.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 pub enum EqualityOp {
     /// =, ==
     Equal(Token),

--- a/src/parse/gml/expressions/evaluation.rs
+++ b/src/parse/gml/expressions/evaluation.rs
@@ -37,7 +37,7 @@ impl ParseVisitor for Evaluation {
 
 /// The various evaluation operations supported in gml.
 #[derive(Debug, PartialEq, Copy, Clone, serde::Serialize)]
-#[serde(tag = "type", content = "token", rename_all = "snake_case")]
+#[serde(tag = "op", content = "token", rename_all = "snake_case")]
 pub enum EvaluationOp {
     /// +
     Plus(Token),

--- a/src/parse/gml/expressions/evaluation.rs
+++ b/src/parse/gml/expressions/evaluation.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt, Token};
 
 /// A mathmatical evaluation.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Evaluation {
     /// The left hand side of the evaluation.
     pub left: Expr,
@@ -36,7 +36,8 @@ impl ParseVisitor for Evaluation {
 }
 
 /// The various evaluation operations supported in gml.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 pub enum EvaluationOp {
     /// +
     Plus(Token),

--- a/src/parse/gml/expressions/function.rs
+++ b/src/parse/gml/expressions/function.rs
@@ -6,6 +6,7 @@ use super::Identifier;
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Function {
     /// The name, if any, of this function. Anonymous functions do not have names.
+    #[serde(flatten)]
     pub name: Option<Identifier>,
     /// The parameters of this function.
     pub parameters: Vec<Field>,
@@ -72,8 +73,8 @@ impl ParseVisitor for Function {
                 Field::Initialized(_) => {}
             }
         }
-        if let Some(Constructor::WithInheritance(inheritance_call)) = &self.constructor {
-            visitor(inheritance_call);
+        if let Some(Constructor { inheritance: Some(call) }) = &self.constructor {
+            visitor(call);
         }
     }
     fn visit_child_exprs_mut<E: FnMut(&mut Expr)>(&mut self, mut visitor: E) {
@@ -83,8 +84,8 @@ impl ParseVisitor for Function {
                 Field::Initialized(_) => {}
             }
         }
-        if let Some(Constructor::WithInheritance(inheritance_call)) = &mut self.constructor {
-            visitor(inheritance_call);
+        if let Some(Constructor { inheritance: Some(call) }) = &mut self.constructor {
+            visitor(call);
         }
     }
     fn visit_child_stmts<S: FnMut(&Stmt)>(&self, mut visitor: S) {
@@ -109,9 +110,7 @@ impl ParseVisitor for Function {
 
 /// Representation of a constructor's behavior in a function declaration.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-pub enum Constructor {
-    /// A constructor that inherits from the nested call.
-    WithInheritance(Expr),
-    /// A constructor that does not inherit from another constructor.
-    WithoutInheritance,
+pub struct Constructor {
+    /// The inheritance call this constructor has, if any.
+    pub inheritance: Option<Expr>,
 }

--- a/src/parse/gml/expressions/function.rs
+++ b/src/parse/gml/expressions/function.rs
@@ -3,7 +3,7 @@ use crate::parse::{Expr, ExprKind, IntoExpr, Field, ParseVisitor, Stmt, StmtKind
 use super::Identifier;
 
 /// Representation of function declaration in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Function {
     /// The name, if any, of this function. Anonymous functions do not have names.
     pub name: Option<Identifier>,
@@ -108,7 +108,7 @@ impl ParseVisitor for Function {
 }
 
 /// Representation of a constructor's behavior in a function declaration.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub enum Constructor {
     /// A constructor that inherits from the nested call.
     WithInheritance(Expr),

--- a/src/parse/gml/expressions/grouping.rs
+++ b/src/parse/gml/expressions/grouping.rs
@@ -1,11 +1,12 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Span, Stmt, Token, TokenKind};
 
 /// Representation of a grouping in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Grouping {
     /// The inner expression contained by this grouping.
     pub inner: Expr,
     /// The parentehsis tokens used in this grouping.
+    #[serde(skip)]
     pub tokens: (Token, Token),
 }
 impl Grouping {

--- a/src/parse/gml/expressions/identifier.rs
+++ b/src/parse/gml/expressions/identifier.rs
@@ -1,11 +1,12 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Span, Stmt};
 
 /// Representation of an identifier in gml, which could be any variable.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Identifier {
     /// The name of this identifier
     pub lexeme: String,
     /// The span that came from the original token
+    #[serde(skip)]
     pub span: Span,
 }
 impl Identifier {

--- a/src/parse/gml/expressions/literal.rs
+++ b/src/parse/gml/expressions/literal.rs
@@ -6,7 +6,7 @@ use super::Identifier;
 
 /// Representation of a literal in gml, aka a constant compile-time value.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-#[serde(rename_all = "snake_case")]
+#[serde(rename_all = "snake_case", tag = "literal", content = "value")]
 pub enum Literal {
     /// true
     True,

--- a/src/parse/gml/expressions/logical.rs
+++ b/src/parse/gml/expressions/logical.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt, Token};
 
 /// Representation of an logical expression in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Logical {
     /// The left hand side of the logical assessment.
     pub left: Expr,
@@ -36,7 +36,8 @@ impl ParseVisitor for Logical {
 }
 
 /// The various logical operations supported in gml.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 pub enum LogicalOp {
     /// and, &&
     And(Token),

--- a/src/parse/gml/expressions/null_coalecence.rs
+++ b/src/parse/gml/expressions/null_coalecence.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt};
 
 /// Representation of a null coalecence evaluation in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct NullCoalecence {
     /// The left hand side of the null coalecence evaluation.
     pub left: Expr,

--- a/src/parse/gml/expressions/postfix.rs
+++ b/src/parse/gml/expressions/postfix.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt, Token};
 
 /// Representation of a postfix operation in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Postfix {
     /// The left hand side of the postfix operation.
     pub left: Expr,
@@ -32,7 +32,8 @@ impl ParseVisitor for Postfix {
 }
 
 /// The various postfix operations supported in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 pub enum PostfixOp {
     /// ++
     Increment(Token),

--- a/src/parse/gml/expressions/postfix.rs
+++ b/src/parse/gml/expressions/postfix.rs
@@ -33,7 +33,7 @@ impl ParseVisitor for Postfix {
 
 /// The various postfix operations supported in gml.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-#[serde(tag = "type", content = "token", rename_all = "snake_case")]
+#[serde(tag = "op", content = "token", rename_all = "snake_case")]
 pub enum PostfixOp {
     /// ++
     Increment(Token),

--- a/src/parse/gml/expressions/ternary.rs
+++ b/src/parse/gml/expressions/ternary.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt};
 
 /// Representation of a ternary evaluation in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Ternary {
     /// The left hand side of the evaluation.
     pub condition: Expr,

--- a/src/parse/gml/expressions/unary.rs
+++ b/src/parse/gml/expressions/unary.rs
@@ -33,7 +33,7 @@ impl ParseVisitor for Unary {
 
 /// The various unary operations supported in gml.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-#[serde(tag = "type", content = "token", rename_all = "snake_case")]
+#[serde(tag = "op", content = "token", rename_all = "snake_case")]
 pub enum UnaryOp {
     /// ++
     Increment(Token),

--- a/src/parse/gml/expressions/unary.rs
+++ b/src/parse/gml/expressions/unary.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, ExprKind, IntoExpr, ParseVisitor, Stmt, Token};
 
 /// Representation of a unary operation in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Unary {
     /// The unary operator.
     pub op: UnaryOp,
@@ -32,7 +32,8 @@ impl ParseVisitor for Unary {
 }
 
 /// The various unary operations supported in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 pub enum UnaryOp {
     /// ++
     Increment(Token),

--- a/src/parse/gml/field.rs
+++ b/src/parse/gml/field.rs
@@ -4,7 +4,7 @@ use super::{Expr, Identifier, Stmt};
 /// parameters, which can be optionally initialized. Will either contain an Expr with an Identifier,
 /// or a Stmt with an Assignment.
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
-#[serde(tag = "type", rename_all = "snake_case")]
+#[serde(tag = "field", content = "value", rename_all = "snake_case")]
 pub enum Field {
     /// Uninitialized definition, containing only their name as an identifier as an
     /// expression.

--- a/src/parse/gml/optional_initialization.rs
+++ b/src/parse/gml/optional_initialization.rs
@@ -3,7 +3,8 @@ use super::{Expr, Identifier, Stmt};
 /// Representation of a field, such as local variables, enum fields, and function
 /// parameters, which can be optionally initialized. Will either contain an Expr with an Identifier,
 /// or a Stmt with an Assignment.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
 pub enum Field {
     /// Uninitialized definition, containing only their name as an identifier as an
     /// expression.

--- a/src/parse/gml/statements/assignment.rs
+++ b/src/parse/gml/statements/assignment.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind, Token};
 
 /// Representation of an assignment statement in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Assignment {
     /// The left hand side of the assignment, aka the target.
     pub left: Expr,
@@ -36,7 +36,8 @@ impl ParseVisitor for Assignment {
 }
 
 /// The various assignment operations supported in gml.
-#[derive(Debug, PartialEq, Copy, Clone)]
+#[derive(Debug, PartialEq, Copy, Clone, serde::Serialize)]
+#[serde(tag = "type", content = "token", rename_all = "snake_case")]
 #[allow(clippy::enum_variant_names)]
 pub enum AssignmentOp {
     /// =, :=

--- a/src/parse/gml/statements/block.rs
+++ b/src/parse/gml/statements/block.rs
@@ -4,11 +4,12 @@ use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind, Token};
 ///
 /// Currently only describes blocks of statements that are
 /// surrounded in braces, but its definition may be expanded in the future.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Block {
     /// The statements contained in this block.
     pub body: Vec<Stmt>,
     /// The delimiter style of this block.
+    #[serde(skip)]
     pub delimiters: Option<(Token, Token)>,
 }
 impl Block {

--- a/src/parse/gml/statements/delete.rs
+++ b/src/parse/gml/statements/delete.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// A delete statement, used to manually free memory.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Delete {
     /// The value being freed.
     pub value: Expr,

--- a/src/parse/gml/statements/do_until.rs
+++ b/src/parse/gml/statements/do_until.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a do/until loop in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct DoUntil {
     /// The body of the loop.
     pub body: Stmt,

--- a/src/parse/gml/statements/enum.rs
+++ b/src/parse/gml/statements/enum.rs
@@ -1,9 +1,11 @@
 use crate::parse::{Expr, Identifier, IntoStmt, Field, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of an enum.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Enum {
     /// The name of the enum.
+    #[serde(flatten)]
     pub name: Identifier,
     /// The OptionalInitilization's this enum contains.
     pub members: Vec<Field>,

--- a/src/parse/gml/statements/for.rs
+++ b/src/parse/gml/statements/for.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a for loop in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct For {
     /// The initializing statement in the for loop.
     pub initializer: Stmt,

--- a/src/parse/gml/statements/globalvar.rs
+++ b/src/parse/gml/statements/globalvar.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, Identifier, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a globalvar in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Globalvar {
     /// The name of the declared globalvar.
     pub name: Identifier,

--- a/src/parse/gml/statements/globalvar.rs
+++ b/src/parse/gml/statements/globalvar.rs
@@ -4,6 +4,7 @@ use crate::parse::{Expr, Identifier, IntoStmt, ParseVisitor, Stmt, StmtKind};
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Globalvar {
     /// The name of the declared globalvar.
+    #[serde(flatten)]
     pub name: Identifier,
 }
 impl Globalvar {

--- a/src/parse/gml/statements/if.rs
+++ b/src/parse/gml/statements/if.rs
@@ -3,7 +3,7 @@ use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 /// Representation of an if statement in gml.
 ///
 /// I'm aware that its absolutely chaotic that I named this thing `If`.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct If {
     /// The condition this if statement is checking for.
     pub condition: Expr,
@@ -20,6 +20,7 @@ pub struct If {
     /// }
     /// ```
     /// The above is valid gml. The keyword does absolutely nothing.
+    #[serde(skip)]
     pub uses_then_keyword: bool,
 }
 impl If {

--- a/src/parse/gml/statements/local_variables.rs
+++ b/src/parse/gml/statements/local_variables.rs
@@ -2,7 +2,7 @@ use crate::parse::{Expr, IntoStmt, Field, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a local variable declaration. Due to gml's syntax, this can include multiple
 /// definitions!
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct LocalVariables {
     /// The various declarations in this series.
     pub declarations: Vec<Field>,

--- a/src/parse/gml/statements/macro.rs
+++ b/src/parse/gml/statements/macro.rs
@@ -13,6 +13,7 @@ use crate::parse::{Expr, Identifier, IntoStmt, ParseVisitor, Stmt, StmtKind};
 #[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Macro {
     /// The name this macro was declared with.
+    #[serde(flatten)]
     pub name: Identifier,
     /// The config (if any) the macro is bound to.
     pub config: Option<String>,

--- a/src/parse/gml/statements/macro.rs
+++ b/src/parse/gml/statements/macro.rs
@@ -10,7 +10,7 @@ use crate::parse::{Expr, Identifier, IntoStmt, ParseVisitor, Stmt, StmtKind};
 /// This is a perfectly valid macro in gml since their bodies are just pasted over their references
 /// early in the compilation process. In the future, we may add macro unfolding to the parsing
 /// process, but for now, they exist in this form mostly just to inform us of their existence.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Macro {
     /// The name this macro was declared with.
     pub name: Identifier,

--- a/src/parse/gml/statements/repeat.rs
+++ b/src/parse/gml/statements/repeat.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a repeat loop in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Repeat {
     /// The expression dictating the amount of ticks.
     pub tick_counts: Expr,

--- a/src/parse/gml/statements/return.rs
+++ b/src/parse/gml/statements/return.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// A return statement, with an optional return value.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Return {
     /// The value, if any, that this statement returns.
     pub value: Option<Expr>,

--- a/src/parse/gml/statements/switch.rs
+++ b/src/parse/gml/statements/switch.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Access, Expr, ExprKind, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a gml switch statement.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Switch {
     /// The value this switch statement is matching over.
     pub matching_value: Expr,
@@ -119,7 +119,7 @@ impl ParseVisitor for Switch {
 /// bodies should be made into `Block`s. While its not of huge concern right
 /// now, it will be an issue when static analyisis is added, as case bodies won't
 /// properly create a new scope.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct SwitchCase(Expr, Vec<Stmt>);
 impl SwitchCase {
     /// Creates a new GmlSwitchCase with the given identity and body.

--- a/src/parse/gml/statements/throw.rs
+++ b/src/parse/gml/statements/throw.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// A throw statement, contianing the value thrown.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct Throw {
     /// The value that is thrown as an exception.
     pub value: Expr,

--- a/src/parse/gml/statements/try_catch.rs
+++ b/src/parse/gml/statements/try_catch.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a try/catch/finally block in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct TryCatch {
     /// The statement to try.
     pub try_body: Stmt,

--- a/src/parse/gml/statements/while.rs
+++ b/src/parse/gml/statements/while.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a while loop in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct While {
     /// The condition of this loop.
     pub condition: Expr,

--- a/src/parse/gml/statements/with.rs
+++ b/src/parse/gml/statements/with.rs
@@ -1,7 +1,7 @@
 use crate::parse::{Expr, IntoStmt, ParseVisitor, Stmt, StmtKind};
 
 /// Representation of a with loop in gml.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
 pub struct With {
     /// The expression representing the symbol being iterated over.
     pub identity: Expr,

--- a/src/parse/gml/stmt.rs
+++ b/src/parse/gml/stmt.rs
@@ -298,7 +298,7 @@ impl std::fmt::Display for Stmt {
                 i.condition,
                 i.else_stmt.as_ref().map(|e| format!(" else {e}")).unwrap_or_default()
             )),
-            StmtKind::Switch(switch) => f.pad(&format!("switch {} {{ ... }}", switch.matching_value)),
+            StmtKind::Switch(switch) => f.pad(&format!("switch {} {{ ... }}", switch.identity)),
             StmtKind::Block(_) => f.pad("{ ... }"),
             StmtKind::Return(ret) => f.pad(&format!(
                 "return{};",

--- a/src/parse/gml/stmt.rs
+++ b/src/parse/gml/stmt.rs
@@ -5,7 +5,8 @@ use crate::{parse::*, FileId};
 use super::{Assignment, Return, Throw};
 
 /// A singular gml statement.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(tag = "stmt_kind", rename_all = "snake_case")]
 pub enum StmtKind {
     /// Declaration of an enum.
     Enum(Enum),
@@ -190,11 +191,16 @@ impl StmtKind {
 }
 
 /// A wrapper around a Stmt, containing additional information discovered while parsing.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
 pub struct Stmt {
+    #[serde(flatten)]
     stmt_type: Box<StmtKind>,
+    #[serde(skip)]
     id: StmtId,
+    #[serde(skip)]
     location: Location,
+    #[serde(skip_serializing_if = "Option::is_none")]
     tag: Option<Tag>,
 }
 impl Stmt {
@@ -333,7 +339,7 @@ pub trait IntoStmt: Sized + Into<StmtKind> {
 }
 
 /// A unique id that each [Stmt] has.
-#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default)]
+#[derive(Debug, Hash, PartialEq, Eq, Clone, Copy, Default, serde::Serialize)]
 pub struct StmtId(u64);
 impl StmtId {
     /// Creates a new, random StmtId.

--- a/src/parse/gml/token.rs
+++ b/src/parse/gml/token.rs
@@ -1,13 +1,11 @@
 #![allow(missing_docs)]
-
+use super::{AssignmentOp, EqualityOp, EvaluationOp, Literal, LogicalOp, PostfixOp, UnaryOp};
+use crate::parse::Span;
 use std::fmt::Display;
 
-use crate::parse::Span;
-
-use super::{AssignmentOp, EqualityOp, EvaluationOp, Literal, LogicalOp, PostfixOp, UnaryOp};
-
 /// A combination of a TokenType and the Span it originates from.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, serde::Serialize)]
+#[serde(into = "String")]
 pub struct Token {
     pub token_type: TokenKind,
     pub span: Span,
@@ -127,9 +125,14 @@ impl Display for Token {
         f.pad(&self.token_type.to_string())
     }
 }
+impl From<Token> for String {
+    fn from(val: Token) -> Self {
+        val.to_string()
+    }
+}
 
 /// An individual token of gml.
-#[derive(Debug, PartialEq, Clone, Copy)]
+#[derive(Debug, PartialEq, Clone, Copy, serde::Serialize)]
 pub enum TokenKind {
     Switch,
     Case,

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -388,9 +388,7 @@ impl Parser {
             let left = self.new_expr(name, span);
             let local_variable = if let Some(equal) = self.match_take(TokenKind::Equal) {
                 let right = self.expr()?;
-                Field::Initialized(
-                    self.new_stmt(Assignment::new(left, AssignmentOp::Identity(equal), right), start),
-                )
+                Field::Initialized(self.new_stmt(Assignment::new(left, AssignmentOp::Identity(equal), right), start))
             } else {
                 Field::Uninitialized(left)
             };
@@ -687,9 +685,7 @@ impl Parser {
                         let name = self.new_expr(name, Span::new(parameter_start, end));
                         if let Some(token) = self.match_take(TokenKind::Equal) {
                             let assignment = Assignment::new(name, AssignmentOp::Identity(token), self.expr()?);
-                            parameters.push(Field::Initialized(
-                                self.new_stmt(assignment, parameter_start),
-                            ));
+                            parameters.push(Field::Initialized(self.new_stmt(assignment, parameter_start)));
                         } else {
                             parameters.push(Field::Uninitialized(name));
                         };
@@ -705,10 +701,9 @@ impl Parser {
                 None
             };
             let constructor = if self.match_take(TokenKind::Constructor).is_some() {
-                match inheritance {
-                    Some((_, inheritance)) => Some(Constructor::WithInheritance(inheritance)),
-                    None => Some(Constructor::WithoutInheritance),
-                }
+                Some(Constructor {
+                    inheritance: inheritance.map(|(_, v)| v),
+                })
             } else {
                 if let Some((colon, inheritance)) = inheritance {
                     return Err(Diagnostic::error()

--- a/src/parse/parser.rs
+++ b/src/parse/parser.rs
@@ -1198,7 +1198,7 @@ impl Parser {
 
 /// A start and end cursor measured in characters, used for expressing small sections of source
 /// code.
-#[derive(Debug, PartialEq, Default, Copy, Clone)]
+#[derive(Debug, PartialEq, Default, Copy, Clone, serde::Serialize)]
 pub struct Span(usize, usize);
 impl Span {
     /// Creates a new span.
@@ -1229,5 +1229,5 @@ impl From<Span> for Range<usize> {
 }
 
 /// A location for something in gml, combining a span and a file id.
-#[derive(Debug, PartialEq, Default, Copy, Clone)]
+#[derive(Debug, PartialEq, Default, Copy, Clone, serde::Serialize)]
 pub struct Location(pub FileId, pub Span);

--- a/src/parse/tests/expr_tests.rs
+++ b/src/parse/tests/expr_tests.rs
@@ -71,7 +71,7 @@ expr_test!(
     Function::new_constructor(
         Some(Identifier::lazy("foo")),
         vec![],
-        Constructor::WithoutInheritance,
+        Constructor { inheritance: None },
         Block::lazy(vec![]).into_stmt_lazy(),
     )
 );
@@ -82,7 +82,9 @@ expr_test!(
     Function::new_constructor(
         Some(Identifier::lazy("foo")),
         vec![],
-        Constructor::WithInheritance(Call::new(Identifier::lazy("bar").into_expr_lazy(), vec![]).into_expr_lazy()),
+        Constructor {
+            inheritance: Some(Call::new(Identifier::lazy("bar").into_expr_lazy(), vec![]).into_expr_lazy())
+        },
         Block::lazy(vec![]).into_stmt_lazy(),
     )
 );


### PR DESCRIPTION
Implements a new command (`duck emit`) to serialize the Asts from a project or single file.

![image](https://user-images.githubusercontent.com/39664206/168383613-b5f42582-1256-4153-b38b-eba2e98f4505.png)

Given the following gml in `example.gml`:
```gml
self.foo = {
    bar: 0
};

return self.foo.bar != 5;
```

`duck emit output.yaml -p example.gml -f yaml` yields the following:

````yaml
----
/Users/gabe/Documents/example.gml:
  stmts:
    - stmt_kind: assignment
      left:
        expr_kind: access
        type: identity
        lexeme: foo
      op:
        type: identity
        token: "="
      right:
        expr_kind: literal
        struct:
          - name:
              lexeme: bar
            value:
              expr_kind: literal
              real: 0.0
    - stmt_kind: return
      value:
        expr_kind: equality
        left:
          expr_kind: access
          type: dot
          left:
            expr_kind: access
            type: identity
            lexeme: foo
          lexeme: bar
        op:
          type: not_equal
          token: "!="
        right:
          expr_kind: literal
          real: 5.0
```
